### PR TITLE
Add Streaming Capability

### DIFF
--- a/src/gui.py
+++ b/src/gui.py
@@ -22,6 +22,7 @@ class DocQA_GUI(QWidget):
     def __init__(self):
         super().__init__()
         initialize_system()
+        self.cumulative_response = ""
         self.metrics_bar = MetricsBar()
         self.compute_device = self.metrics_bar.determine_compute_device()
         os_name = self.metrics_bar.get_os_name()
@@ -130,6 +131,7 @@ class DocQA_GUI(QWidget):
     def on_submit_button_clicked(self):
         user_question = self.text_input.toPlainText()
         self.submit_button_thread = SubmitButtonThread(user_question, self)
+        self.cumulative_response = ""
         self.submit_button_thread.responseSignal.connect(self.update_response)
         self.submit_button_thread.start()
 
@@ -146,7 +148,8 @@ class DocQA_GUI(QWidget):
             yaml.dump(config, file)
 
     def update_response(self, response):
-        self.read_only_text.setPlainText(response)
+        self.cumulative_response += response
+        self.read_only_text.setPlainText(self.cumulative_response)
 
     def update_transcription(self, text):
         self.text_input.setPlainText(text)

--- a/src/gui_threads.py
+++ b/src/gui_threads.py
@@ -17,4 +17,5 @@ class SubmitButtonThread(QThread):
 
     def run(self):
         response = server_connector.ask_local_chatgpt(self.user_question)
-        self.responseSignal.emit(response['answer'])
+        for response_chunk in response:
+            self.responseSignal.emit(response_chunk)


### PR DESCRIPTION
Adds streaming

Note: if you click the "Submit Questions" before it's done streaming, it does reset the inbox, but it doesn't also stop the previous stream so they end up getting mixed together. It seems a bit harder to stop an existing stream than I expected, so perhaps we can implement something that greys out the submit button until the current request is done processing later on.